### PR TITLE
Update to v5.23.5 and create a README with color scheme workaround info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# org.gtk.Gtk3theme.Breeze
+### Workarounds
+- Using a custom color scheme (etc. Breeze Dark) and ascent color. Related issue [#3901](https://github.com/flatpak/flatpak/issues/3901).
+  ```sh
+  flatpak override --user --filesystem=xdg-config/gtk-3.0:ro
+  ```

--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -92,13 +92,13 @@
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze-gtk.git",
-          "tag": "v5.23.2",
+          "tag": "v5.23.4",
           "dest": "breeze-gtk"
         },
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze.git",
-          "tag": "v5.23.2",
+          "tag": "v5.23.4",
           "dest": "breeze"
         }
       ],

--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -92,13 +92,13 @@
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze-gtk.git",
-          "tag": "v5.23.4",
+          "tag": "v5.23.5",
           "dest": "breeze-gtk"
         },
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze.git",
-          "tag": "v5.23.4",
+          "tag": "v5.23.5",
           "dest": "breeze"
         }
       ],

--- a/python-deps.json
+++ b/python-deps.json
@@ -14,16 +14,28 @@
           "type": "file",
           "url": "https://pypi.org/packages/source/p/pycairo/pycairo-1.20.1.tar.gz",
           "sha256": "1ee72b035b21a475e1ed648e26541b04e5d7e753d75ca79de8c583b25785531b"
+          "x-checker-data": {
+            "type": "pypi",
+            "name": "pycairo"
+          }
         },
         {
           "type": "file",
           "url": "https://pypi.org/packages/source/s/setuptools/setuptools-58.2.0.tar.gz",
           "sha256": "2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145"
+          "x-checker-data": {
+            "type": "pypi",
+            "name": "setuptools"
+          }
         },
         {
           "type": "file",
           "url": "https://pypi.org/packages/source/w/wheel/wheel-0.37.0.tar.gz",
           "sha256": "e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad"
+          "x-checker-data": {
+            "type": "pypi",
+            "name": "wheel"
+          }
         }
       ]
     }

--- a/python-deps.json
+++ b/python-deps.json
@@ -14,28 +14,16 @@
           "type": "file",
           "url": "https://pypi.org/packages/source/p/pycairo/pycairo-1.20.1.tar.gz",
           "sha256": "1ee72b035b21a475e1ed648e26541b04e5d7e753d75ca79de8c583b25785531b"
-          "x-checker-data": {
-            "type": "pypi",
-            "name": "pycairo"
-          }
         },
         {
           "type": "file",
           "url": "https://pypi.org/packages/source/s/setuptools/setuptools-58.2.0.tar.gz",
           "sha256": "2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145"
-          "x-checker-data": {
-            "type": "pypi",
-            "name": "setuptools"
-          }
         },
         {
           "type": "file",
           "url": "https://pypi.org/packages/source/w/wheel/wheel-0.37.0.tar.gz",
           "sha256": "e2ef7239991699e3355d54f8e968a21bb940a1dbf34a4d226741e64462516fad"
-          "x-checker-data": {
-            "type": "pypi",
-            "name": "wheel"
-          }
         }
       ]
     }


### PR DESCRIPTION
Provides information on how to use KDE Plasma's color schemes and ascent color with the Breeze theme on flatpak using a workaround.