### PR TITLE
Create a README with color scheme workaround info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# org.gtk.Gtk3theme.Breeze
+### Workarounds
+- Using a custom color scheme (etc. Breeze Dark) and ascent color. Related issue [#3901](https://github.com/flatpak/flatpak/issues/3901).
+  ```sh
+  flatpak override --user --filesystem=xdg-config/gtk-3.0:ro
+  ```


### PR DESCRIPTION
Provides information on how to use KDE Plasma's color schemes and ascent color with the Breeze theme on flatpak using a workaround.

Split from #13 