### PR TITLE
Update to v5.24.0

### DIFF
--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -84,7 +84,7 @@
       ],
       "build-commands": [
         "find breeze-gtk/src -name '*.scss' -print -execdir sed -i 's#\\.\\./assets/#./assets/#' {} \\;",
-        "cd breeze-gtk/src && sed -i 's/@PYTHON_EXECUTABLE@/python3/g' build_theme.sh.cmake && ./build_theme.sh.cmake -c Breeze -t ${FLATPAK_BUILDER_BUILDDIR}/Breeze -r ${FLATPAK_BUILDER_BUILDDIR}/breeze/colors",
+        "cd breeze-gtk/src && sed -i 's/@PYTHON_EXECUTABLE@/python3/g' build_theme.sh.cmake && ./build_theme.sh.cmake -c BreezeLight -t ${FLATPAK_BUILDER_BUILDDIR}/Breeze -r ${FLATPAK_BUILDER_BUILDDIR}/breeze/colors",
         "cp -rv --no-preserve=ownership ${FLATPAK_BUILDER_BUILDDIR}/Breeze/gtk-3.0/* ${FLATPAK_DEST}",
         "cp -rv --no-preserve=ownership ${FLATPAK_BUILDER_BUILDDIR}/Breeze/assets ${FLATPAK_DEST}"
       ],
@@ -92,13 +92,13 @@
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze-gtk.git",
-          "tag": "v5.23.5",
+          "tag": "v5.24.0",
           "dest": "breeze-gtk"
         },
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze.git",
-          "tag": "v5.23.5",
+          "tag": "v5.24.0",
           "dest": "breeze"
         }
       ],

--- a/python-deps.json
+++ b/python-deps.json
@@ -17,8 +17,8 @@
         },
         {
           "type": "file",
-          "url": "https://pypi.org/packages/source/s/setuptools/setuptools-60.2.0.tar.gz",
-          "sha256": "675fcebecb43c32eb930481abf907619137547f4336206e4d673180242e1a278"
+          "url": "https://pypi.org/packages/source/s/setuptools/setuptools-60.8.1.tar.gz",
+          "sha256": "23aad87cc27f4ae704079618c1d117a71bd43d41e355f0698c35f6b1c796d26c"
         },
         {
           "type": "file",


### PR DESCRIPTION
Bumped version to v5.24.0, also changed to build with Breeze Light color scheme to match upstream defaults. https://invent.kde.org/plasma/breeze-gtk/-/commit/67b9c38a4a91438147ede38aa9306f9b0acc78ff