### PR TITLE
Update to 5.24.5

### DIFF
--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -92,13 +92,13 @@
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze-gtk.git",
-          "tag": "v5.24.1",
+          "tag": "v5.24.5",
           "dest": "breeze-gtk"
         },
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze.git",
-          "tag": "v5.24.1",
+          "tag": "v5.24.5",
           "dest": "breeze"
         }
       ],


### PR DESCRIPTION
The Breeze GTK theme has had *a lot* of updates that bring its appearance much more in-line with the Qt theme, so I feel like this is a pretty important update. A subsequent pull request will add f-e-d-c information so that these updates can come in more easily.