### PR TITLE
Flatpak External Data Checker

### DIFF
--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -92,13 +92,13 @@
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze-gtk.git",
-          "tag": "v5.24.1",
+          "tag": "v5.24.5",
           "dest": "breeze-gtk"
         },
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze.git",
-          "tag": "v5.24.1",
+          "tag": "v5.24.5",
           "dest": "breeze"
         }
       ],

--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -93,13 +93,23 @@
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze-gtk.git",
           "tag": "v5.24.5",
-          "dest": "breeze-gtk"
+          "commit": "e630a07a28d675241e9c054699fd762baf13a800",
+          "dest": "breeze-gtk",
+          "x-checker-data": {
+            "type": "git",
+            "tag-pattern": "^v([\\d.]+)$"
+          }
         },
         {
           "type": "git",
           "url": "https://invent.kde.org/plasma/breeze.git",
           "tag": "v5.24.5",
-          "dest": "breeze"
+          "commit": "a58410a5de09d54d75c9bd5b7328fc73e6a83365",
+          "dest": "breeze",
+          "x-checker-data": {
+            "type": "git",
+            "tag-pattern": "^v([\\d.]+)$"
+          }
         }
       ],
       "modules": [

--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -90,25 +90,27 @@
       ],
       "sources": [
         {
-          "type": "git",
-          "url": "https://invent.kde.org/plasma/breeze-gtk.git",
-          "tag": "v5.24.5",
-          "commit": "e630a07a28d675241e9c054699fd762baf13a800",
+          "type": "archive",
+          "url": "https://download.kde.org/stable/plasma/5.24.5/breeze-gtk-5.24.5.tar.xz",
+          "sha256": "23716cc08d570ddcf0e739fef2f585f3469d801313ab2c0ba89f494f93f94530",
           "dest": "breeze-gtk",
           "x-checker-data": {
-            "type": "git",
-            "tag-pattern": "^v([\\d.]+)$"
+            "type": "anitya",
+            "project-id": 8761,
+            "stable-only": true,
+            "url-template": "https://download.kde.org/stable/plasma/$version/breeze-gtk-$version.tar.xz"
           }
         },
         {
-          "type": "git",
-          "url": "https://invent.kde.org/plasma/breeze.git",
-          "tag": "v5.24.5",
-          "commit": "a58410a5de09d54d75c9bd5b7328fc73e6a83365",
+          "type": "archive",
+          "url": "https://download.kde.org/stable/plasma/5.24.5/breeze-5.24.5.tar.xz",
+          "sha256": "8525a6b50da5523c3d21c1223e0f2b8ad4a2d147e48e5d128e1c6ee06baaf0a3",
           "dest": "breeze",
           "x-checker-data": {
-            "type": "git",
-            "tag-pattern": "^v([\\d.]+)$"
+            "type": "anitya",
+            "project-id": 8761,
+            "stable-only": true,
+            "url-template": "https://download.kde.org/stable/plasma/$version/breeze-$version.tar.xz"
           }
         }
       ],


### PR DESCRIPTION
Adds data for FEDC to be able to automatically check for new versions of the Breeze themes and generate automated PRs accordingly. The PR adds a commit hash to both theme repos because it seems like FEDC uses that to check whether things are up-to-date rather than tags specified in the manifest.