### PR TITLE
Switch to beta branch, because stable never actually got any changes.

### DIFF
--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -91,14 +91,14 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.kde.org/stable/plasma/5.24.5/breeze-gtk-5.24.5.tar.xz",
-          "sha256": "23716cc08d570ddcf0e739fef2f585f3469d801313ab2c0ba89f494f93f94530",
+          "url": "https://download.kde.org/unstable/plasma/5.24.90/breeze-gtk-5.24.90.tar.xz",
+          "sha256": "2430ec851e3f521e5f76208b72c2eccf6abf3b8e2e3b4b23c054e892feae2598",
           "dest": "breeze-gtk",
           "x-checker-data": {
             "type": "anitya",
             "project-id": 8761,
-            "stable-only": true,
-            "url-template": "https://download.kde.org/stable/plasma/$version/breeze-gtk-$version.tar.xz"
+            "stable-only": false,
+            "url-template": "https://download.kde.org/unstable/plasma/$version/breeze-gtk-$version.tar.xz"
           }
         },
         {


### PR DESCRIPTION
Okay, so I'm a darn fool. Part of why I made the PRs I did was because I noticed how the git version of Breeze GTK fixes some of the stark differences between the Qt and GTK Breeze themes, the most harsh one being context menu highlights. I made a presumption that surely some of those changes were being pushed back into the 5.24 branch as appropriate, right? ...Right?

[No, they haven't done *jack diddly squat* with the 5.24 branch.](https://invent.kde.org/plasma/breeze-gtk/-/commits/Plasma/5.24)

The differences between the 5.25 beta GTK theme and the 5.24.5 Qt theme are much, much less than the 5.24 GTK theme and the 5.24.5 Qt theme. Mainly, there is a small amount of padding on popup menus, which is going to be in the 5.25 Qt theme.

I strongly think that this version of the GTK theme will make for a much better experience for users of Flatpak GTK apps, so I'm submitting this PR. Thanks for your consideration.