### PR TITLE
Include gtk-dark.css and clarify workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # org.gtk.Gtk3theme.Breeze
 ### Workarounds
-- Using a custom color scheme (etc. Breeze Dark) and ascent color. Related issue [#3901](https://github.com/flatpak/flatpak/issues/3901).
+- Using a custom color scheme and ascent color on KDE Plasma. Requires restarting app after changing color scheme/ascent settings for it to apply. Related issue [#3901](https://github.com/flatpak/flatpak/issues/3901).
   ```sh
-  flatpak override --user --filesystem=xdg-config/gtk-3.0:ro
+  flatpak override --user --filesystem=xdg-config/gtk-3.0/settings.ini:ro \
+  --filesystem=xdg-config/gtk-3.0/gtk.css:ro \
+  --filesystem=xdg-config/gtk-3.0/colors.css:ro
   ```

--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -85,7 +85,9 @@
                 "find breeze-gtk/src -name '*.scss' -print -execdir sed -i 's#\\.\\./assets/#./assets/#' {} \\;",
                 "cd breeze-gtk/src && sed -i 's/@PYTHON_EXECUTABLE@/python3/g' build_theme.sh.cmake && ./build_theme.sh.cmake -c BreezeLight -t ${FLATPAK_BUILDER_BUILDDIR}/Breeze -r ${FLATPAK_BUILDER_BUILDDIR}/breeze/colors",
                 "cp -rv --no-preserve=ownership ${FLATPAK_BUILDER_BUILDDIR}/Breeze/gtk-3.0/* ${FLATPAK_DEST}",
-                "cp -rv --no-preserve=ownership ${FLATPAK_BUILDER_BUILDDIR}/Breeze/assets ${FLATPAK_DEST}"
+                "cp -rv --no-preserve=ownership ${FLATPAK_BUILDER_BUILDDIR}/Breeze/assets ${FLATPAK_DEST}",
+                "cd breeze-gtk/src && ./build_theme.sh.cmake -c BreezeDark -t ${FLATPAK_BUILDER_BUILDDIR}/Breeze -r ${FLATPAK_BUILDER_BUILDDIR}/breeze/colors",
+                "cp -rv --no-preserve=ownership ${FLATPAK_BUILDER_BUILDDIR}/Breeze/gtk-3.0/gtk.css ${FLATPAK_DEST}/gtk-dark.css"
             ],
             "sources": [
                 {


### PR DESCRIPTION
- Fixes theme not being used in certain GTK apps such as Flatseal when a dark color scheme such as Breeze Dark is selected.
- Allows switching between light/dark theme if not using override.
- Clarify and specify files in workaround to avoid access to potentially sensitive files such as bookmarks.