### PR TITLE
Add f-e-d-c to buil deps and update color scheme workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # org.gtk.Gtk3theme.Breeze
 ### Workarounds
-- Using a custom color scheme and ascent color on KDE Plasma. Requires restarting app after changing color scheme/ascent settings for it to apply. Related issue [#3901](https://github.com/flatpak/flatpak/issues/3901).
+- Using a custom color scheme and ascent color on KDE Plasma. Requires restarting app after changing color scheme/ascent settings for it to apply. Related issue [#3901](https://github.com/flatpak/flatpak/issues/3901). Note: This will also expose the GTK's bookmarks and [servers](https://help.gnome.org/admin/system-admin-guide/stable/network-server-list.html.en) files under ~/.config/gtk-3.0/ if they are present.
   ```sh
-  flatpak override --user --filesystem=xdg-config/gtk-3.0/settings.ini:ro \
-  --filesystem=xdg-config/gtk-3.0/gtk.css:ro \
-  --filesystem=xdg-config/gtk-3.0/colors.css:ro
+  flatpak override --user --filesystem=xdg-config/gtk-3.0:ro
   ```

--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -27,7 +27,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/sass/sassc/archive/3.6.2.tar.gz",
-                    "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03"
+                    "sha256": "608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 12485,
+                        "stable-only": true,
+                        "url-template": "https://github.com/sass/sassc/archive/$version.tar.gz"
+                    }
                 },
                 {
                     "type": "script",
@@ -48,7 +54,13 @@
                         {
                             "type": "archive",
                             "url": "https://github.com/sass/libsass/archive/3.6.5.tar.gz",
-                            "sha512": "98cc7e12fdf74cd9e92d8d4a62b821956d3ad186fcee9a8d77b677a621342aa161b73d9adad4c1849678a3bac890443120cc8febe1b7429aab374321d635b8f7"
+                            "sha512": "98cc7e12fdf74cd9e92d8d4a62b821956d3ad186fcee9a8d77b677a621342aa161b73d9adad4c1849678a3bac890443120cc8febe1b7429aab374321d635b8f7",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 11766,
+                                "stable-only": true,
+                                "url-template": "https://github.com/sass/libsass/archive/$version.tar.gz"
+                            }
                         },
                         {
                             "type": "script",

--- a/python-deps.json
+++ b/python-deps.json
@@ -12,18 +12,30 @@
       "sources": [
         {
           "type": "file",
-          "url": "https://pypi.org/packages/source/p/pycairo/pycairo-1.20.1.tar.gz",
-          "sha256": "1ee72b035b21a475e1ed648e26541b04e5d7e753d75ca79de8c583b25785531b"
+          "url": "https://files.pythonhosted.org/packages/92/a4/506564f574fa74c90b98690e8ecc8dbae1629f31fcfe0be69de45d9e1605/pycairo-1.21.0.tar.gz",
+          "sha256": "251907f18a552df938aa3386657ff4b5a4937dde70e11aa042bc297957f4b74b",
+          "x-checker-data": {
+              "type": "pypi",
+              "name": "pycairo"
+          }
         },
         {
           "type": "file",
-          "url": "https://pypi.org/packages/source/s/setuptools/setuptools-60.8.1.tar.gz",
-          "sha256": "23aad87cc27f4ae704079618c1d117a71bd43d41e355f0698c35f6b1c796d26c"
+          "url": "https://files.pythonhosted.org/packages/67/25/42e2d6664c3e106c33ecad8356a55e3ae5d81708c89098061a97fbff7cee/setuptools-63.1.0.tar.gz",
+          "sha256": "16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
+          "x-checker-data": {
+              "type": "pypi",
+              "name": "setuptools"
+          }
         },
         {
           "type": "file",
-          "url": "https://pypi.org/packages/source/w/wheel/wheel-0.37.1.tar.gz",
-          "sha256": "e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4"
+          "url": "https://files.pythonhosted.org/packages/c0/6c/9f840c2e55b67b90745af06a540964b73589256cb10cc10057c87ac78fc2/wheel-0.37.1.tar.gz",
+          "sha256": "e9a504e793efbca1b8e0e9cb979a249cf4a0a7b5b8c9e8b65a5e39d49529c1c4",
+          "x-checker-data": {
+              "type": "pypi",
+              "name": "wheel"
+          }
         }
       ]
     }


### PR DESCRIPTION
Added f-e-d-c to the sass and cairo dependencies. For the color scheme workaround looks like flatpak didn't allow the override to go through if the gtk-3.0 folder didn't exist under the application's config folders. Changing the workaround to an override of the gtk-3.0 folder again but with the note that it can expose the bookmarks and servers files.