### PR TITLE
Update `readMe`, to improve override guidance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
-# org.gtk.Gtk3theme.Breeze
+# `org.gtk.Gtk3theme.Breeze`
+
 ### Workarounds
-- Using a custom color scheme and accent color on KDE Plasma. Requires restarting app after changing color scheme/accent settings for it to apply. Related issue [#3901](https://github.com/flatpak/flatpak/issues/3901). Note: This will also expose the GTK's bookmarks and [servers](https://help.gnome.org/admin/system-admin-guide/stable/network-server-list.html.en) files under ~/.config/gtk-3.0/ if they are present.
-  ```sh
-  flatpak override --user --filesystem=xdg-config/gtk-3.0:ro
-  ```
+
+Using a custom color scheme and accent color on KDE Plasma requires restarting the app after changing the color scheme/accent settings for it to apply. The related issue is [#3901](https://github.com/flatpak/flatpak/issues/3901).
+
+> [!NOTE]
+> This will also expose the GTK's bookmarks and [servers](https://help.gnome.org/admin/system-admin-guide/stable/network-server-list.html.en) files under `$HOME/.config/gtk-3.0/` if they are present.
+
+```sh
+#!/usr/bin/env sh
+flatpak override --system \
+    --filesystem=xdg-config/gtk-3.0:ro \
+    --filesystem=xdg-config/gtkrc-2.0:ro \
+    --filesystem=xdg-config/gtk-4.0:ro \
+    --filesystem=xdg-config/gtkrc:ro \
+```
+
+Superuser permission may be necessary.


### PR DESCRIPTION
#### Update `readMe.MD` to: expand shell-specific commands into shell-inspecific, 1:1, environment variables; convert unsemantic code into `code`; and add absent overrides for GTK4, icons, and fonts.

1. Replaced the BaSH-ism for XDG_HOME (`~`) with `$HOME` since this works in more shells - it's an env var.

1. Remediates https://github.com/flathub/org.gtk.Gtk3theme.Breeze/issues/212#issue-2824654066, by including addition overrides for GTK4.

1. More semantically renders the "Note" section in accordance with GHFM recommendations.

1. More semantically renders the title as code, because it is reverse DNS.

1. Likewise, the path is codified, because it is a path.

1. Includes a shebang to indicate which shell should be utilised to invoke the commands in, since there must be a recommended one, and some interpret separators differently, etcetera.