### PR TITLE
feat: bump runtime to 24.08

### DIFF
--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -2,7 +2,7 @@
     "id": "org.gtk.Gtk3theme.Breeze",
     "branch": "3.22",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
     "appstream-compose": false,

--- a/org.gtk.Gtk3theme.Breeze.json
+++ b/org.gtk.Gtk3theme.Breeze.json
@@ -5,7 +5,6 @@
     "runtime-version": "24.08",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
-    "appstream-compose": false,
     "separate-locales": false,
     "cleanup-commands": [
         "rm -rvf ${FLATPAK_DEST}/_pfx"
@@ -135,8 +134,7 @@
             "name": "appdata",
             "buildsystem": "simple",
             "build-commands": [
-                "install -Dm644 org.gtk.Gtk3theme.Breeze.appdata.xml -t ${FLATPAK_DEST}/share/appdata",
-                "appstream-compose --basename=org.gtk.Gtk3theme.Breeze --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Breeze"
+                "install -Dm644 org.gtk.Gtk3theme.Breeze.appdata.xml -t ${FLATPAK_DEST}/share/appdata"
             ],
             "sources": [
                 {


### PR DESCRIPTION
We don't need to have a manual compose anymore as far as I understand, this is done by flatpak-builder now
the `files/share/app-info/xmls/org.gtk.Gtk3theme.Breeze.xml.gz` file still exists without the manual compose.

See:
https://docs.flatpak.org/en/latest/extension.html#extension-manifest
https://github.com/flathub/org.freedesktop.Sdk.Extension.node18/issues/52

The theme itself still works, tested with eye of gnome.