### PR TITLE
Document the issue with dark mode on the apps using X11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
   ```sh
   flatpak override --user --filesystem=xdg-config/gtk-3.0:ro
   ```
+- Dark theme is known to be broken in the app using X11, related issue [#170](https://github.com/flathub/org.gtk.Gtk3theme.Breeze/issues/170). There is no workaround at the moment, you can use another theme (e.g. Adwaita or Adapta) as an alternative.


### PR DESCRIPTION
Dark mode is known to be broken with Breeze theme on flatpak apps using X11, so document it in README

See #170 for details